### PR TITLE
add container deployer example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+
+**/transport.tar

--- a/container-deployer/Docker/Dockerfile
+++ b/container-deployer/Docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3
+
+RUN pip install --no-cache kubernetes pyyaml
+
+ENTRYPOINT [ "python" ]

--- a/container-deployer/README.md
+++ b/container-deployer/README.md
@@ -1,0 +1,11 @@
+# Examples using the Container Deployer
+
+### Example [container-1](./container-1)
+
+This example deploys a Kubernetes configmap using the container deployer and a python base container image.
+The user can specify the name, namespace and the content of the deployed configmap in the data imports.
+The example exports the following data objects:
+
+* `configmapdata`: Contains the data section of the deployed configmap.
+* `component`: Contains the component name and version used by the installation.
+* `content`: Contains the list and file properties of blueprint files provided to the container deployer.

--- a/container-deployer/commands/push-docker-image.sh
+++ b/container-deployer/commands/push-docker-image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKERFILE_DIR="$(dirname $0)/../Docker"
+NAME="container-deployer"
+VERSION="v0.1.0"
+OCI_REPO="eu.gcr.io/gardener-project/landscaper/examples/images"
+
+docker build -t "${OCI_REPO}/${NAME}:${VERSION}" --platform amd64 $DOCKERFILE_DIR
+docker push "${OCI_REPO}/${NAME}:${VERSION}"

--- a/container-deployer/container-1/blueprint/blueprint.yaml
+++ b/container-deployer/container-1/blueprint/blueprint.yaml
@@ -1,0 +1,48 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+jsonSchema: "https://json-schema.org/draft/2019-09/schema"
+
+imports:
+- name: targetCluster
+  required: true
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+- name: configmap
+  required: true
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+      namespace:
+        type: string
+      content:
+        type: object
+        properties:
+          key:
+            type: string
+          value:
+            type: string
+
+exports:
+- name: configMapData
+  schema:
+    type: object
+
+- name: component
+  schema:
+    type: object
+
+- name: content
+  schema:
+    type: array
+
+deployExecutions:
+  - name: deploy-execution
+    type: GoTemplate
+    file: /deploy-execution.yaml
+
+exportExecutions:
+  - name: export-execution
+    type: GoTemplate
+    file: /export-execution.yaml

--- a/container-deployer/container-1/blueprint/deploy-execution.yaml
+++ b/container-deployer/container-1/blueprint/deploy-execution.yaml
@@ -1,0 +1,19 @@
+deployItems:
+- name: container-deployer
+  type: landscaper.gardener.cloud/container
+  target:
+    name: {{ index .imports "targetCluster" "metadata" "name" }}
+    namespace: {{ index .imports "targetCluster" "metadata" "namespace" }}
+  config:
+    apiVersion: container.deployer.landscaper.gardener.cloud/v1alpha1
+    kind: ProviderConfiguration
+    {{- $image := getResource .cd "name" "container-deployer-base" }}
+    image: {{ $image.access.imageReference }}
+    command: ["sh"]
+    args: ["-c", "python ${CONTENT_PATH}/script.py"]
+    importValues:
+      {{ toJson .imports | indent 6 }}
+    componentDescriptor:
+      {{ toJson .componentDescriptorDef | indent 6 }}
+    blueprint:
+      {{ toJson .blueprint | indent 6 }}

--- a/container-deployer/container-1/blueprint/export-execution.yaml
+++ b/container-deployer/container-1/blueprint/export-execution.yaml
@@ -1,0 +1,7 @@
+exports:
+  configMapData:
+    {{- index .values "deployitems" "container-deployer" "configMapData" | toYaml | nindent 4 }}
+  component:
+    {{- index .values "deployitems" "container-deployer" "component" | toYaml | nindent 4 }}
+  content:
+    {{- index .values "deployitems" "container-deployer" "content" | toYaml | nindent 4 }}

--- a/container-deployer/container-1/blueprint/script.py
+++ b/container-deployer/container-1/blueprint/script.py
@@ -1,0 +1,113 @@
+import sys
+import os
+import yaml
+
+from kubernetes import client, config
+
+def load_kube_config(imports: dict):
+    kubeconfig = yaml.safe_load(imports["targetCluster"]["spec"]["config"]["kubeconfig"])
+    config.load_kube_config_from_dict(config_dict=kubeconfig)
+
+def reconcile(imports: dict):
+    configmap_import = imports["configmap"]
+    name = configmap_import["name"]
+    namespace = configmap_import["namespace"]
+    configmap = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": name 
+        },
+        "data": {
+            configmap_import["content"]["key"]: configmap_import["content"]["value"]
+        }
+    }
+
+    v1 = client.CoreV1Api()
+    res = list(v1.list_namespaced_config_map(namespace=namespace, watch=False, field_selector=f"metadata.name={name}").items)
+    
+    if len(res) == 0:
+        print(f"create configmap {namespace}/{name}")
+        v1.create_namespaced_config_map(namespace=namespace, body=configmap)
+    else:
+        print(f"updating configmap {namespace}/{name}")
+        v1.replace_namespaced_config_map(namespace=namespace, name=name, body=configmap)
+
+    res = list(v1.list_namespaced_config_map(namespace=namespace, watch=False, field_selector=f"metadata.name={name}").items)
+    return res[0].data
+
+def delete(imports: dict):
+    configmap_import = imports["configmap"]
+    name = configmap_import["name"]
+    namespace = configmap_import["namespace"]
+
+    v1 = client.CoreV1Api()
+    res = list(v1.list_namespaced_config_map(namespace=namespace, watch=False, field_selector=f"metadata.name={name}").items)
+    
+    if len(res) > 0:
+        print(f"deleting configmap {namespace}/{name}")
+        v1.delete_namespaced_config_map(namespace=namespace, name=name)
+
+def write_exports(configmap_data: dict, components: dict, content_path: str, exports_path: str):
+    print(f"writing exports to {exports_path}")
+
+    component = components["components"][0]
+    content_files = next(os.walk(content_path), (None, None, []))[2]
+    content = []
+
+    for file in content_files:
+        abs_path = os.path.join(content_path, file)
+        print(f"accessing {abs_path}")
+        stat = os.stat(abs_path)
+        content.append({
+            "name": file,
+            "stat": {
+                "size": stat.st_size,
+                "mode": stat.st_mode,
+                "uid": stat.st_uid,
+                "gid": stat.st_gid
+            }
+        })
+
+    exports = {
+        "configMapData": configmap_data,
+        "component": {
+            "name": component["component"]["name"],
+            "version": component["component"]["version"]
+        },
+        "content": content,
+    }
+    with open(exports_path, 'w') as f:
+        f.write(yaml.safe_dump(exports))
+
+def main(argv=None):
+    imports_path = os.environ["IMPORTS_PATH"]
+    exports_path = os.environ["EXPORTS_PATH"]
+    component_descriptor_path = os.environ["COMPONENT_DESCRIPTOR_PATH"]
+    content_path = os.environ["CONTENT_PATH"]
+    operation = os.environ["OPERATION"]
+
+    print(f"imports_path={imports_path}")
+    print(f"exports_path={exports_path}")
+    print(f"component_descriptor_path={component_descriptor_path}")
+    print(f"content_path={content_path}")
+    print(f"operation={operation}")
+
+    with open(imports_path, 'r') as f:
+        imports = yaml.safe_load(f.read())
+
+    with open(component_descriptor_path, 'r') as f:
+        components = yaml.safe_load(f.read())
+
+    load_kube_config(imports)
+
+    if operation.lower() == "reconcile":
+        configmap_data = reconcile(imports)
+        write_exports(configmap_data, components, content_path, exports_path)
+    else:
+        delete(imports)
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/container-deployer/container-1/commands/create-and-push-component.sh
+++ b/container-deployer/container-1/commands/create-and-push-component.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPONENT_DIR="$(dirname $0)/.."
+TRANSPORT_FILE=${COMPONENT_DIR}/commands/transport.tar
+
+../../hack/create-and-push-component.sh "${COMPONENT_DIR}" "${TRANSPORT_FILE}"

--- a/container-deployer/container-1/component-descriptor.yaml
+++ b/container-deployer/container-1/component-descriptor.yaml
@@ -1,0 +1,24 @@
+meta:
+  schemaVersion: v2
+component:
+  name: github.com/gardener/landscaper-examples/container-deployer/container-1
+  version: v0.1.0
+
+  repositoryContexts:
+    - baseUrl: eu.gcr.io/gardener-project/landscaper/examples
+      type: ociRegistry
+
+  provider: internal
+  
+  componentReferences: []
+
+  sources: []
+
+  resources:
+    - access:
+        imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/landscaper-python:v1.0.0
+        type: ociRegistry
+      name: landscaper-python
+      relation: external
+      type: ociImage
+      version: v1.0.0

--- a/container-deployer/container-1/component-descriptor.yaml
+++ b/container-deployer/container-1/component-descriptor.yaml
@@ -14,11 +14,4 @@ component:
 
   sources: []
 
-  resources:
-    - access:
-        imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/landscaper-python:v1.0.0
-        type: ociRegistry
-      name: landscaper-python
-      relation: external
-      type: ociImage
-      version: v1.0.0
+  resources: []

--- a/container-deployer/container-1/installation/installation.yaml
+++ b/container-deployer/container-1/installation/installation.yaml
@@ -1,0 +1,42 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: container-1
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
+spec:
+  blueprint:
+    ref:
+      resourceName: blueprint
+
+  componentDescriptor:
+    ref:
+      componentName: github.com/gardener/landscaper-examples/container-deployer/container-1
+      repositoryContext:
+        baseUrl: eu.gcr.io/gardener-project/landscaper/examples
+        type: ociRegistry
+      version: v0.1.0
+
+  imports:
+    targets:
+      - name: targetCluster
+        target: '#target-cluster'
+
+  importDataMappings:
+    configmap:
+      name: example-configmap
+      namespace: default
+      content:
+        key: mykey
+        value: myvalue
+
+  exports:
+    data:
+    - name: configMapData
+      dataRef: configmapdata
+
+    - name: component
+      dataRef: component
+
+    - name: content
+      dataRef: content

--- a/container-deployer/container-1/resources.yaml
+++ b/container-deployer/container-1/resources.yaml
@@ -1,0 +1,20 @@
+---
+type: blueprint
+name: blueprint
+version: v0.1.0
+relation: local
+input:
+  type: dir
+  path: ./blueprint
+  mediaType: application/vnd.gardener.landscaper.blueprint.v1+tar+gzip
+  compress: true
+...
+---
+type: ociImage
+name: container-deployer-base
+version: v0.1.0
+relation: external
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/container-deployer:v0.1.0
+...


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an example for the Landscaper container deployer using a python base image and a python script to deploy a Kubernetes configmap.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add Landscaper container deployer example.
```
